### PR TITLE
fix: make options user overridable

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -88,9 +88,9 @@ export default new class {
             viteOptions.vite.server.watch.ignored.push(`**/${options.output}/*.html`)
         }
 
-        lodash.merge(options, viteOptions)
+        lodash.merge(viteOptions, options)
 
-        this.options = options
+        this.options = viteOptions
 
         return new Promise(async resolve => {
             // defines server instance in the Serve class


### PR DESCRIPTION
The way the merge of options is currently arranged makes it so that none of the default vite options are overridable.

By flipping the order you can now override the default options